### PR TITLE
One must call waitpid() after PTRACE_ATTACH to avoid racing

### DIFF
--- a/unwind-pid.c
+++ b/unwind-pid.c
@@ -1,6 +1,7 @@
-#include <sys/ptrace.h>
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/ptrace.h>
 
 #include <libunwind-ptrace.h>
 
@@ -16,6 +17,8 @@ int main(int argc, char **argv)
 	pid_t pid = atoi(argv[1]);
 	if (ptrace(PTRACE_ATTACH, pid, 0, 0) != 0)
 		die("ERROR: cannot attach to %d\n", pid);
+	int status;
+	assert(waitpid(pid, &status, 0) == 0);
 
 	void *context = _UPT_create(pid);
 	unw_cursor_t cursor;


### PR DESCRIPTION
The current example has a race condition (which always triggers for me). As documented in the ptrace man page, after calling PTRACE_ATTACH the remote process may not be stopped yet. To ensure it is stopped (necessary for the other ptrace calls) one should use waitpid().